### PR TITLE
Update repository clone URL in README files

### DIFF
--- a/Live-coding-prototype/README.md
+++ b/Live-coding-prototype/README.md
@@ -18,7 +18,7 @@ A PHP command-line interface (CLI) tool for converting numbers between decimal, 
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/your-username/number-converter-cli.git
+   git clone https://github.com/BENYEKHLEF-Anouar/Calculatrice-logique-binaire.git
    cd number-converter-cli
    ```
 2. Install Composer dependencies:

--- a/Prototype/README.md
+++ b/Prototype/README.md
@@ -18,7 +18,7 @@ A PHP command-line interface (CLI) tool for converting numbers between decimal, 
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/your-username/number-converter-cli.git
+   git clone https://github.com/BENYEKHLEF-Anouar/Calculatrice-logique-binaire.git
    cd number-converter-cli
    ```
 2. Install Composer dependencies:


### PR DESCRIPTION
Changed the example git clone URL in both README.md files to point to the correct repository: BENYEKHLEF-Anouar/Calculatrice-logique-binaire.